### PR TITLE
update styling edge cases. add alt to img tag. remove unnecessary react imports. update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GuideCX: Frontend
+# GuideCX: Frontend Take-home Project
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GuideCX: Frontend Take-home Project
+# GuideCX: Frontend Assessment
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
@@ -23,19 +23,19 @@ npm install
 cp .env.example .env
 ```
 
-- [Create a personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) and save it to your `.env` file. The scopes you require depends on the type of data you're wanting to fetch. The following list is a good start:
+- [Create a personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) and save it to your `.env` file. The scopes you require depends on the type of data you're wanting to fetch. The following configuration is a good start:
 
 ```
-user
-public_repo
-repo
-repo_deployment
-repo:status
-read:repo_hook
-read:org
-read:public_key
-read:gpg_key
+  - repo
+    - repo_deployment
+    - public_repo
+  - user
+    - read:user
+    - user:email
 ```
+
+![](https://i.imgur.com/8TUUi0D.jpg)
+
 
 - **Explore the Github GraphQL API**: If you're new to the Github GraphQL API, you may consider spending a few minutes exploring the public schema to get an idea of what data is available. See [Github GraphQL Explorer](https://docs.github.com/en/graphql/overview/explorer).
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ You've got access to a lot of Github data. There's a placeholder component at [.
 
 Some examples:
 
-- Search
-- Analyzer
-- Vulnerability Checker
+- Search Repos
+- List which repos have been forked by your followers
+- Compare analytics between multiple repos
+- List all vulnerabilities of selected repos, filter by vulnerability type
 
 Here are some ground rules:
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@guidecx/frontend-test",
-  "description": "Take-home exercise for working with React and GraphQL",
+  "description": "Take-home exercise for working with React",
   "version": "1.0.0",
-  "private": true,
+  "private": false,
   "dependencies": {
     "@apollo/client": "^3.3.7",
     "graphql": "^15.5.0",

--- a/src/components/profile/index.tsx
+++ b/src/components/profile/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { gql } from '@apollo/client';
 
 interface ProfileProps {
@@ -34,7 +33,11 @@ const Profile: React.FC<ProfileProps> = ({ user }) => {
   return (
     <div className='profile w-full h-full'>
       <div className='avatar ring-4 ring-gray-500 ring-offset-2 rounded-3xl'>
-        <img className='rounded-3xl w-full' src={user?.avatarUrl} />
+        <img
+          className='rounded-3xl w-full'
+          src={user?.avatarUrl}
+          alt='user profile'
+        />
       </div>
       <h1 className='pt-2 text-2xl'>{user?.name}</h1>
       <h2 className='font-thin text-xl leading-loose'>{user?.username}</h2>

--- a/src/components/user-repos/index.tsx
+++ b/src/components/user-repos/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { gql } from '@apollo/client';
 
 import './user-repos.scss';
@@ -29,10 +28,10 @@ interface Props {
 
 const UserRepos: React.FC<Props> = ({ repos = [] }) => {
   return (
-    <div className='user-repos mx-8 w-full h-full'>
+    <div className='user-repos flex flex-col mx-8 w-full h-full min-h-full'>
       <h3 className='text-3xl mb-6 font-semibold'>Repositories</h3>
-      <div className='p-4 grid xlg:grid-cols-3 grid-cols-2	gap-4 bg-gray-100 dark:bg-gray-900 rounded shadow-md h-4/5'>
-        {repos.map((repo) => (
+      <div className='p-4 grid xlg:grid-cols-3 grid-cols-2 gap-4 bg-gray-100 dark:bg-gray-900 rounded shadow-md h-full mb-16'>
+        {repos.map(repo => (
           <div
             key={repo.id}
             className='flex flex-col justify-center p-4 px-8 border rounded border-gray-700'

--- a/src/containers/app/index.tsx
+++ b/src/containers/app/index.tsx
@@ -29,7 +29,7 @@ function App() {
   return (
     <DefaultLayout className='app-container'>
       <div className='h-full flex flex-row'>
-        <div className='w-1/4'>
+        <div className='pt-3 w-1/4'>
           <Profile user={data?.viewer} />
         </div>
         <UserRepos repos={data?.viewer?.repositories?.nodes || []} />

--- a/src/containers/magic/index.tsx
+++ b/src/containers/magic/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const Magic: React.FC = () => {
   return (
     <div className='magic container flex flex-col h-full justify-center items-center'>

--- a/src/layouts/default/index.tsx
+++ b/src/layouts/default/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Link } from 'react-router-dom';
 
 interface Props {
@@ -6,18 +5,22 @@ interface Props {
 }
 
 const DefaultLayout: React.FC<Props> = ({ children, className }) => {
+  if (!process.env.REACT_APP_GITHUB_ACCESS_KEY) {
+    throw new Error(
+      'Missing environment variable: REACT_APP_GITHUB_ACCESS_KEY'
+    );
+  }
+
   return (
-    <div
-      className={`h-full grid grid-rows-layout auto-rows-max gap-4 default-layout ${className}`}
-    >
+    <div className={`min-h-full flex flex-col default-layout ${className}`}>
       <header className='p-4 text-2xl bg-white dark:bg-gray-700 shadow-md'>
         <div className='container mx-auto space-x-10'>
           <Link to='/'>Profile</Link>
           <Link to='/magic'>Magic</Link>
         </div>
       </header>
-      <main>
-        <div className='container mx-auto h-full mt-8'>{children}</div>
+      <main className='min-h-full flex flex-grow'>
+        <div className='container mx-auto pt-8'>{children}</div>
       </main>
       <footer className='p-8 bg-gray-300 dark:bg-gray-900'>
         <div className='container mx-auto flex flex-column items-center h-full'>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 
 import App from './containers/app';


### PR DESCRIPTION
Change Notes:

- This repo uses `react@17` so unless we're directly referencing the `React` object, we do not need to import it. updated files to reflect this version
- Set `package.json::private` to `false` since this is a public repo
- add alt tag to `img` tag to remove console warning
- there was an edge-case styling issue where the users repos would overflow the parent container. updated styling to remove this bug
- add console error to let user know they have not added their github key to the `.env` file
- update readme to include image of github key configuration and alt config text